### PR TITLE
Advertise source and version via User-Agent (v0.1.11)

### DIFF
--- a/nodes/Roam/transport.ts
+++ b/nodes/Roam/transport.ts
@@ -11,12 +11,14 @@ import type {
   JsonObject,
 } from "n8n-workflow";
 
+import { version } from "../../package.json";
+
 type RoamFunctions = IExecuteFunctions | ILoadOptionsFunctions | IWebhookFunctions | IHookFunctions;
 
 // Advertised to the Roam appserver on every request for version attribution in
-// logs and Datadog (@plugin.name:n8n-nodes-roam / @plugin.version). Keep in sync
-// with package.json "version".
-const ROAM_USER_AGENT = "n8n-nodes-roam/0.1.11";
+// logs and Datadog (@plugin.name:n8n-nodes-roam / @plugin.version). Version is
+// read from package.json so a release only bumps it in one place.
+const ROAM_USER_AGENT = `n8n-nodes-roam/${version}`;
 
 /**
  * Make an API request to Roam

--- a/nodes/Roam/transport.ts
+++ b/nodes/Roam/transport.ts
@@ -13,6 +13,11 @@ import type {
 
 type RoamFunctions = IExecuteFunctions | ILoadOptionsFunctions | IWebhookFunctions | IHookFunctions;
 
+// Advertised to the Roam appserver on every request for version attribution in
+// logs and Datadog (@plugin.name:n8n-nodes-roam / @plugin.version). Keep in sync
+// with package.json "version".
+const ROAM_USER_AGENT = "n8n-nodes-roam/0.1.11";
+
 /**
  * Make an API request to Roam
  */
@@ -41,6 +46,7 @@ export async function apiRequest(
     headers: {
       Accept: "application/json",
       "Content-Type": "application/json",
+      "User-Agent": ROAM_USER_AGENT,
     },
     body,
     qs,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-roam",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-roam",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "license": "MIT",
       "devDependencies": {
         "@n8n/node-cli": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-roam",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "n8n community node to work with the Roam API",
   "license": "MIT",
   "homepage": "https://ro.am",


### PR DESCRIPTION
## What
Stamp `User-Agent: n8n-nodes-roam/<version>` on every Roam API request.

## Why
Requests from this node currently carry n8n's generic default User-Agent, so the Roam appserver can't tell which integration (or version) is calling. This advertises a real product token, queryable in Datadog as `@plugin.name:n8n-nodes-roam` / `@plugin.version` (the appserver already parses `name/version` User-Agents into those facets).

## How
- `nodes/Roam/transport.ts` — add `"User-Agent": "n8n-nodes-roam/<version>"` to the headers built in `apiRequest()`, the single chokepoint all node operations route through. No caller overrides headers, so this covers every request.
- Version is a constant kept in sync with `package.json` (no test runner in this repo to guard it).
- Bump `0.1.10` → `0.1.11`.

## Notes
- Forward-only: installs still on ≤0.1.10 keep sending the generic UA, by design.
- Part of an org-wide effort to make all Roam integrations advertise source + version (openclaw-roam shipped this in v0.4.1).