### PR TITLE
Pin Roam API version (Roam-Version: 2026-06-01) — v0.1.12

### DIFF
--- a/nodes/Roam/transport.ts
+++ b/nodes/Roam/transport.ts
@@ -20,6 +20,11 @@ type RoamFunctions = IExecuteFunctions | ILoadOptionsFunctions | IWebhookFunctio
 // read from package.json so a release only bumps it in one place.
 const ROAM_USER_AGENT = `n8n-nodes-roam/${version}`;
 
+// Roam API version this node is built against, sent as `Roam-Version` so the
+// v1 response contract is pinned to this release rather than to whenever the
+// API key was created. Bump deliberately, in lockstep with the parsing code.
+const ROAM_API_VERSION = "2026-06-01";
+
 /**
  * Make an API request to Roam
  */
@@ -49,6 +54,7 @@ export async function apiRequest(
       Accept: "application/json",
       "Content-Type": "application/json",
       "User-Agent": ROAM_USER_AGENT,
+      "Roam-Version": ROAM_API_VERSION,
     },
     body,
     qs,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-roam",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-roam",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "license": "MIT",
       "devDependencies": {
         "@n8n/node-cli": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-roam",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "n8n community node to work with the Roam API",
   "license": "MIT",
   "homepage": "https://ro.am",


### PR DESCRIPTION
## What
Send `Roam-Version: 2026-06-01` on every Roam API request from this node.

## Why
The server is adding Stripe-style dated API versioning; a client's default is pinned at API-key-creation time, not node version. Sending an explicit `Roam-Version` pins the v1 response contract to **this node release**, so future `/v1/` shape changes can't reach an older node until we bump `ROAM_API_VERSION` in lockstep with the parsing code.

## Scope note
This node's REST calls that hit `/v1/` (e.g. `groups.list`) are what this protects. Its **webhooks subscribe on `/v0/`**, which is outside the v1 versioning scheme, so there's no `version` param on `webhook.subscribe` (it'd be meaningless on v0). The header is harmless on the node's `/v0/` calls.

## Safety / timing
No-op until the server ships versioning; an unknown `Roam-Version` header is ignored. Pinned to Baseline `2026-06-01` (always Supported). Deploy before the first real version (`2026-09-01`) goes Latest.

## Test
`npm run build` (n8n-node build) green; emitted `dist` carries the `Roam-Version` header. (No unit-test runner in this repo.)